### PR TITLE
Fix debug_url for the latest version of Chrome

### DIFF
--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -379,7 +379,11 @@ module Capybara
       private
 
       def build_remote_debug_url(path:)
-        "http://#{browser.process.host}:#{browser.process.port}#{path}"
+        uri = URI.parse(path)
+        uri.scheme ||= "http"
+        uri.host ||= browser.process.host
+        uri.port ||= browser.process.port
+        uri.to_s
       end
 
       def default_domain

--- a/spec/features/driver_spec.rb
+++ b/spec/features/driver_spec.rb
@@ -1605,6 +1605,15 @@ module Capybara
 
         expect(@session).to have_content("test_cookie")
       end
+
+      it "has a working debug_url" do
+        session = Capybara::Session.new(:cuprite_with_inspector, TestApp)
+        session.visit "/cuprite/arbitrary_path/200"
+
+        expect do
+          URI.parse(session.driver.debug_url)
+        end.not_to raise_error
+      end
     end
   end
 end

--- a/spec/lib/driver_spec.rb
+++ b/spec/lib/driver_spec.rb
@@ -30,7 +30,7 @@ describe Capybara::Cuprite::Driver do
   end
 
   describe "debug_url" do
-    it "parses the devtools frontend url correctly" do
+    it "parses the devtools frontend url correctly when devtoolsFrontendUrl is relative" do
       driver = described_class.new(nil, { port: 12_345 })
       driver.browser # initialize browser before stubbing Net::HTTP as it also calls it
       uri = instance_double(URI)
@@ -39,6 +39,19 @@ describe Capybara::Cuprite::Driver do
       allow(Net::HTTP).to receive(:get).with(uri).and_return(%([{"devtoolsFrontendUrl":"/works"}]))
 
       expect(driver.debug_url).to eq("http://127.0.0.1:12345/works")
+    end
+
+    it "parses the devtools frontend url correctly when devtoolsFrontendUrl is fully qualified" do
+      driver = described_class.new(nil, { port: 12_346 })
+      driver.browser # initialize browser before stubbing Net::HTTP as it also calls it
+      uri = instance_double(URI)
+
+      allow(driver).to receive(:URI).with("http://127.0.0.1:12346/json").and_return(uri)
+      allow(Net::HTTP).to receive(:get).with(uri).and_return(
+        %([{"devtoolsFrontendUrl":"https://chrome-devtools-frontend.appspot.com/serve_rev?ws=123"}])
+      )
+
+      expect(driver.debug_url).to eq("https://chrome-devtools-frontend.appspot.com/serve_rev?ws=123")
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,10 @@ Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(app, options)
 end
 
+Capybara.register_driver(:cuprite_with_inspector) do |app|
+  Capybara::Cuprite::Driver.new(app, { inspector: true })
+end
+
 module TestSessions
   Cuprite = Capybara::Session.new(:cuprite, TestApp)
 end


### PR DESCRIPTION
the first commit introduces a regression spec that fails in the CI on the latest version of Chrome, the second commit addresses the issue.

solves: https://github.com/rubycdp/cuprite/issues/296